### PR TITLE
fix: keep main window hidden during shortcut recording

### DIFF
--- a/OpenSuperMLX/Indicator/IndicatorWindowManager.swift
+++ b/OpenSuperMLX/Indicator/IndicatorWindowManager.swift
@@ -21,22 +21,7 @@ class IndicatorWindowManager: IndicatorViewDelegate {
         viewModel = newViewModel
 
         if window == nil {
-            // NSPanel for full-screen space compatibility
-            let panel = NSPanel(
-                contentRect: NSRect(x: 0, y: 0, width: 200, height: 60),
-                styleMask: [.borderless, .nonactivatingPanel],
-                backing: .buffered,
-                defer: false
-            )
-
-            panel.isFloatingPanel = true
-            panel.backgroundColor = .clear
-            panel.isOpaque = false
-            panel.hasShadow = false
-            panel.ignoresMouseEvents = true
-            panel.hidesOnDeactivate = false
-
-            self.window = panel
+            window = Self.makePanel()
         }
 
         let targetScreen = point.flatMap { FocusUtils.screenContaining(point: $0) } ?? NSScreen.main
@@ -66,6 +51,25 @@ class IndicatorWindowManager: IndicatorViewDelegate {
 
         window?.orderFront(nil)
         return newViewModel
+    }
+
+    static func makePanel() -> NSPanel {
+        // NSPanel for full-screen space compatibility
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 60),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.isFloatingPanel = true
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = false
+        panel.ignoresMouseEvents = true
+        panel.canHide = false
+        panel.hidesOnDeactivate = false
+        return panel
     }
     
     func stopRecording() {

--- a/OpenSuperMLXTests/IndicatorWindowManagerTests.swift
+++ b/OpenSuperMLXTests/IndicatorWindowManagerTests.swift
@@ -1,0 +1,104 @@
+// IndicatorWindowManagerTests.swift
+// OpenSuperMLXTests
+
+import AppKit
+import XCTest
+
+@testable import OpenSuperMLX
+
+@MainActor
+final class IndicatorWindowManagerTests: XCTestCase {
+    func testShowingIndicatorKeepsApplicationAndMainWindowHidden() async throws {
+        try await withHiddenApplication { application, mainWindow, panel in
+            await showAndCheckApplicationStaysHidden(panel, application: application)
+
+            XCTAssertTrue(panel.isVisible)
+            XCTAssertTrue(application.isHidden)
+            XCTAssertFalse(mainWindow.isVisible)
+            XCTAssertFalse(application.isActive)
+        }
+    }
+
+    func testShowingIndicatorAgainKeepsMainWindowHidden() async throws {
+        try await withHiddenApplication { application, mainWindow, panel in
+            panel.orderFront(nil)
+            panel.orderOut(nil)
+            XCTAssertFalse(panel.isVisible)
+
+            await showAndCheckApplicationStaysHidden(panel, application: application)
+
+            XCTAssertTrue(panel.isVisible)
+            XCTAssertTrue(application.isHidden)
+            XCTAssertFalse(mainWindow.isVisible)
+        }
+    }
+
+    func testShowingIndicatorKeepsClosedMainWindowClosed() async throws {
+        try await withHiddenApplication { application, mainWindow, panel in
+            mainWindow.close()
+
+            await showAndCheckApplicationStaysHidden(panel, application: application)
+
+            XCTAssertTrue(panel.isVisible)
+            XCTAssertTrue(application.isHidden)
+            XCTAssertFalse(mainWindow.isVisible)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func showAndCheckApplicationStaysHidden(
+        _ panel: NSPanel,
+        application: NSApplication
+    ) async {
+        let unhidden = expectation(
+            forNotification: NSApplication.didUnhideNotification,
+            object: application
+        )
+        unhidden.isInverted = true
+
+        panel.orderFront(nil)
+        await fulfillment(of: [unhidden], timeout: 0.1)
+    }
+
+    private func withHiddenApplication(
+        _ body: (NSApplication, NSWindow, NSPanel) async -> Void
+    ) async throws {
+        try XCTSkipIf(NSScreen.screens.isEmpty, "Requires an active display")
+
+        let application = NSApplication.shared
+        let wasHidden = application.isHidden
+        let activationPolicy = application.activationPolicy()
+        let mainWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 100),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        mainWindow.isReleasedWhenClosed = false
+        defer {
+            mainWindow.close()
+            if wasHidden {
+                application.hide(nil)
+            } else {
+                application.unhideWithoutActivation()
+            }
+            application.setActivationPolicy(activationPolicy)
+        }
+
+        application.setActivationPolicy(.regular)
+        mainWindow.orderFrontRegardless()
+        await Task.yield()
+        application.hide(nil)
+        for _ in 0..<100 where !application.isHidden {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        try XCTSkipUnless(application.isHidden, "Application hiding requires a window session")
+        XCTAssertFalse(mainWindow.isVisible)
+
+        let panel = IndicatorWindowManager.makePanel()
+        panel.isReleasedWhenClosed = false
+        defer { panel.close() }
+        await body(application, mainWindow, panel)
+    }
+}


### PR DESCRIPTION
Starting recording with the global shortcut after hiding the app with Cmd-H could restore the main window. Set the recording indicator panel's `canHide` to `false` so the indicator can appear while the app and main window remain hidden, preserving its non-activating behavior.

Extract panel construction for focused AppKit regression tests covering initial presentation, repeated presentation, and a closed main window.

Validation:
- `./run.sh build` passed against the latest `master` dependencies.
- Hosted and hostless XCTest: 539 passed, 14 skipped, zero failures, using the CI test scope.
- All three new regression tests fail without the setting and pass with it.
- The user manually confirmed Cmd-H followed by the recording shortcut keeps the main window hidden.
- Testing and maintainability reviews found no issues.
